### PR TITLE
Fix pylint warning `no-else-return`

### DIFF
--- a/baseline/baseline_utils.py
+++ b/baseline/baseline_utils.py
@@ -198,12 +198,11 @@ def clip(matrix=torch.randn([5,10,30]),standard=[15,15],kernel_size=3,out_channe
             array.append(padding(matrix=conv_res[i,:,:,:],standard=standard))
         res = torch.concat(array,axis=0).reshape([matrix_shape[0],out_channels if out_channels else in_channels,standard[0],standard[1]])
         return res,stride,res.shape
-
-    else:
-        for i in range(conv_res.shape[0]):
-            array.append(padding(matrix=conv_res[i,:,:,:,:],standard=standard))
-        res = torch.concat(array,axis=0).reshape([matrix_shape[0],out_channels if out_channels else in_channels,standard[0],standard[1],standard[2]])     
-        return res,stride,res.shape
+    
+    for i in range(conv_res.shape[0]):
+        array.append(padding(matrix=conv_res[i,:,:,:,:],standard=standard))
+    res = torch.concat(array,axis=0).reshape([matrix_shape[0],out_channels if out_channels else in_channels,standard[0],standard[1],standard[2]])     
+    return res,stride,res.shape
 
 # Residual block
 class ResidualBlock(torch.nn.Module):

--- a/baseline/build_3Dgrid.py
+++ b/baseline/build_3Dgrid.py
@@ -56,40 +56,32 @@ def getObstaclesAndAccessPoints(data,routed_nets,bool_inference):
     return obstacles,accessPoints
 
 
-def _get_adjacent_point(vertex,direction,grid_length,grid_width,grid_height):
-    assert direction in ('east','west','south','north','up','down')
+def _get_adjacent_point(vertex, direction, grid_length, grid_width, grid_height):
+    assert direction in ('east', 'west', 'south', 'north', 'up', 'down')
     if direction == 'west':
         if vertex[0] == 0:
             return -1
-        else:
-            return (vertex[0] - 1,vertex[1],vertex[2])
+        return (vertex[0] - 1, vertex[1], vertex[2])
     if direction == 'east':
         if vertex[0] == grid_length - 1:
             return -1
-        else:
-            return (vertex[0] + 1,vertex[1],vertex[2] )
-
+        return (vertex[0] + 1, vertex[1], vertex[2])
     if direction == 'south':
         if vertex[1] == 0:
             return -1
-        else:
-            return (vertex[0],vertex[1]-1,vertex[2])
+        return (vertex[0], vertex[1] - 1, vertex[2])
     if direction == 'north':
         if vertex[1] == grid_width - 1:
             return -1
-        else:
-            return (vertex[0],vertex[1]+1,vertex[2] )
-
+        return (vertex[0], vertex[1] + 1, vertex[2])
     if direction == 'down':
         if vertex[2] == 0:
             return -1
-        else:
-            return (vertex[0],vertex[1],vertex[2]-1)
+        return (vertex[0], vertex[1], vertex[2] - 1)
     if direction == 'up':
         if vertex[2] == grid_height - 1:
             return -1
-        else:
-            return (vertex[0],vertex[1],vertex[2]+1)
+        return (vertex[0], vertex[1], vertex[2] + 1)
 
 def getObstacleGrid(obstacles,grid_dim):
     grid = []


### PR DESCRIPTION
### Changes Made:

- Applied automated fixes for the pylint warning `no-else-return`.
"Used in order to highlight an unnecessary block of code following an if containing a return statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a return statement.. See [https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html)"

### Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.